### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "data2xml": "1.2.4",
     "ejs-mate": "2.3.0",
     "eventproxy": "0.3.4",
-    "express": "4.13.4",
+    "express": "4.14.0",
     "express-session": "1.12.1",
     "helmet": "1.3.0",
     "ioredis": "1.15.1",


### PR DESCRIPTION
nodeclub is currently affected by the high-severity vulnerability [ReDOS vulnerability](https://snyk.io/vuln/npm:negotiator:20160616). 

Vulnerable module: `negotiator`
Introduced through: `express`

This PR fixes the ReDOS  vulnerability by upgrading `express` to version 4.14.0

You are already watching this repo with Snyk, so check out [the project](https://snyk.io/test/github/cnodejs/nodeclub)  to review other vulnerabilities that affect this repo, and generate a PR to fix more vulnerabilities. 

Stay secure, 
The Snyk team
